### PR TITLE
Add simple voice chat demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# voice_chat
+# Voice Chat Example
+
+This is a simple demo of a responsive web application that provides voice chat with avatars. It uses WebRTC for real time audio and WebSocket for signaling.
+
+## Prerequisites
+- Node.js 16+
+- npm
+
+## Setup
+
+```
+cd server
+npm install
+```
+
+## Running
+
+```
+npm start
+```
+
+Then open `http://localhost:3000` in two browser windows. One window should append `#1` to the URL to act as the initiator (e.g., `http://localhost:3000/#1`). Grant microphone access when prompted.
+
+## Notes
+- Avatars are placeholder images.
+- This example is for demonstration and is not production ready.
+

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,23 @@
+const ws = new WebSocket(location.origin.replace(/^http/, 'ws'));
+let peer;
+
+navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+  .then(stream => {
+    peer = new SimplePeer({ initiator: location.hash === '#1', trickle: false, stream });
+
+    peer.on('signal', data => {
+      ws.send(JSON.stringify(data));
+    });
+
+    peer.on('stream', remoteStream => {
+      const audio = new Audio();
+      audio.srcObject = remoteStream;
+      audio.play();
+    });
+  })
+  .catch(err => console.error('Error accessing media devices.', err));
+
+ws.onmessage = msg => {
+  const data = JSON.parse(msg.data);
+  peer.signal(data);
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Voice Chat with Avatars</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Voice Chat Room</h1>
+  <div id="avatars">
+    <div class="avatar" id="local">
+      <img src="https://via.placeholder.com/150" alt="Local Avatar">
+      <p>You</p>
+    </div>
+    <div class="avatar" id="remote">
+      <img src="https://via.placeholder.com/150" alt="Remote Avatar">
+      <p>Remote</p>
+    </div>
+  </div>
+  <script src="https://unpkg.com/simple-peer@latest/simplepeer.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#avatars {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.avatar {
+  margin: 10px;
+  text-align: center;
+}
+
+.avatar img {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+@media (max-width: 600px) {
+  .avatar img {
+    width: 100px;
+    height: 100px;
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "voice_chat_server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {"start": "node server.js"},
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.15.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const http = require('http');
+const WebSocket = require('ws');
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+app.use(express.static('public'));
+
+wss.on('connection', function connection(ws) {
+  ws.on('message', function incoming(message) {
+    // Broadcast any received signaling data to all other clients
+    wss.clients.forEach(function each(client) {
+      if (client !== ws && client.readyState === WebSocket.OPEN) {
+        client.send(message);
+      }
+    });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server started on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create Node server with Express and WS for signaling
- add client HTML/CSS/JS for WebRTC-based voice chat and avatars
- document setup and running instructions in README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68418eeb168c832c869c1c1fd6146dac